### PR TITLE
Add support for Laravel 9 (PHP 8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
     "name": "josegus/laravel-flash",
     "require": {
-        "php": ">=7.2",
-        "illuminate/session": "^6.0|^7.0|^8.0"
+        "php": "^7.2|^8.0",
+        "illuminate/session": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
         "vimeo/psalm": "^4.7"
     },
     "license": "MIT",


### PR DESCRIPTION
I just tested on Laravel 9 with laravel/breeze installed and it worked.